### PR TITLE
#89 downgrading pyyaml to fix  hallux installation error in docker py…

### DIFF
--- a/hallux/main.py
+++ b/hallux/main.py
@@ -65,7 +65,7 @@ class Hallux:
             return {}, run_path
         config_file = str(config_path.joinpath(CONFIG_FILE))
         with open(config_file) as file_stream:
-            yaml_dict = yaml.load(file_stream, Loader=yaml.CLoader)
+            yaml_dict = yaml.load(file_stream, Loader=yaml.Loader)
             logger.debug(f"Loaded config from {config_file}")
             logger.debug(f"Config: {yaml_dict}")
         return yaml_dict, config_path

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ classifiers = [
 ]
 
 dependencies = [
-  'pyyaml==6.0',
+  'pyyaml==5.3.1',
   'types-PyYAML==6.0.12.11',
   'PyGithub==2.1.1',
   'colorlog==6.7.0',

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ pytest-cov==4.1.0
 ruff==0.0.272
 mypy==1.4.1
 black==24.3.0
-pyyaml==6.0
+pyyaml==5.3.1
 types-PyYAML==6.0.12.11
 PyGithub==2.1.1
 isort==5.12.0


### PR DESCRIPTION
install hallux in docker from python:3.10-alpine3.19